### PR TITLE
Reverse Dutch Auction → Dutch Auction

### DIFF
--- a/models_dutch_auction.md
+++ b/models_dutch_auction.md
@@ -1,4 +1,4 @@
-### **Reverse Dutch Auction approach \(Gnosis, RaidenNetwork, OraclesNetwork\)**
+### **Dutch Auction approach \(Gnosis, RaidenNetwork, OraclesNetwork\)**
 
 [**https://medium.com/@nickikwhite\_5051/token-sale-models-part-ii-price-schedules-b36716a1a9de**](https://medium.com/@nickikwhite_5051/token-sale-models-part-ii-price-schedules-b36716a1a9de)
 


### PR DESCRIPTION
To my knowledge what's explained here is a 'Dutch Auction', which is 'reverse' by definition. If you write 'Reverse Dutch Auction' it's more like double negation and might confuse users to what you mean.

Feel free to ignore this in case you disagree though. : D